### PR TITLE
fix plugin specification

### DIFF
--- a/lib/Dist/Zilla/PluginBundle/BESSARABV.pm
+++ b/lib/Dist/Zilla/PluginBundle/BESSARABV.pm
@@ -67,7 +67,7 @@ sub configure {
         #
         #  [mock_person_pr]: https://github.com/bessarabov/Mock-Person/pull/3
         #  [changes_dzil_test]: http://questhub.io/realm/perl/quest/51f5f0fa852fe91826000012
-        'Dist::Zilla::Plugin::Test::CPAN::Changes',
+        'Test::CPAN::Changes',
 
         # FilePruner
         'Git::ExcludeUntracked',


### PR DESCRIPTION
I tried to do some experiments with Mock::Person dist, but I got an error:

```
sromanov@snapdozer:~/mydev/Mock-Person$ dzil build
Can't locate Dist/Zilla/Plugin/Dist/Zilla/Plugin/Test/CPAN/Changes.pm in @INC (you may need to install the Dist::Zilla::Plugin::Dist::Zilla::Plugin::Test::CPAN::Changes module) (@INC contains: /home/sromanov/perl5/perlbrew/perls/perl-blead/lib/site_perl/5.19.3/i686-linux /home/sromanov/perl5/perlbrew/perls/perl-blead/lib/site_perl/5.19.3 /home/sromanov/perl5/perlbrew/perls/perl-blead/lib/5.19.3/i686-linux /home/sromanov/perl5/perlbrew/perls/perl-blead/lib/5.19.3 .) at /home/sromanov/perl5/perlbrew/perls/perl-blead/lib/site_perl/5.19.3/Module/Runtime.pm line 317, <GEN1> line 11. at /home/sromanov/perl5/perlbrew/perls/perl-blead/lib/site_perl/5.19.3/Config/MVP/Assembler.pm line 87.
```

I fixed the `D::Z::P::Test::CPAN::Changes` plugin specification in your plugin list.
